### PR TITLE
Added support for attributes on the Abbreviation element.

### DIFF
--- a/src/Abbreviation.php
+++ b/src/Abbreviation.php
@@ -3,6 +3,7 @@
 namespace Eightfold\CommonMarkAbbreviations;
 
 use League\CommonMark\Inline\Element\AbstractInline;
+use League\CommonMark\HtmlElement;
 
 class Abbreviation extends AbstractInline
 {
@@ -22,6 +23,10 @@ class Abbreviation extends AbstractInline
 
     public function element()
     {
-        return '<abbr title="'. $this->title .'">'. $this->abbr .'</abbr>';
+        $attributes = $this->getData('attributes', []);
+
+        $attributes['title'] = $this->title;
+
+        return new HtmlElement('abbr', $attributes, $this->abbr);
     }
 }

--- a/tests/AbbreviationAttributesTest.php
+++ b/tests/AbbreviationAttributesTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Eightfold\CommonMarkAbbreviations\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+use League\CommonMark\Environment;
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
+
+use Eightfold\Shoop\Shoop;
+
+use Eightfold\CommonMarkAbbreviations\Abbreviation;
+use Eightfold\CommonMarkAbbreviations\AbbreviationExtension;
+
+class AbbreviationAttributesTest extends TestCase
+{
+    public function testParser()
+    {
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new AbbreviationExtension());
+        $environment->addExtension(new ExternalLinkExtension());
+        $environment->addEventListener(DocumentParsedEvent::class, function (
+            DocumentParsedEvent $event
+        ) {
+            $document = $event->getDocument();
+            $walker = $document->walker();
+            while ($event = $walker->next()) {
+                $node = $event->getNode();
+
+                // Ignore any nodes that aren't Abbreviation nodes, and only act
+                // when we first encounter/enter an Abbreviation node.
+                if (!($node instanceof Abbreviation) || !$event->isEntering()) {
+                    continue;
+                }
+
+                // Add a test attribute. It's also possible to alter the
+                // existing attributes here.
+                $node->data['attributes']['data-event-attribute'] = 'hello';
+            }
+        });
+        $converter = new CommonMarkConverter([
+            "external_link" => ["open_in_new_window" => true]
+        ], $environment);
+
+        $path = Shoop::this(__DIR__)->append("/short-doc-attributes.md");
+        $markdown = file_get_contents($path);
+        $expected = '<p><abbr title="United States Web Design System" data-inline-attribute="hello" data-event-attribute="hello">USWDS</abbr></p>'."\n".'<p><a rel="noopener noreferrer" target="_blank" href="https://8fold.pro">External link check</a></p>'."\n";
+        $actual = $converter->convertToHtml($markdown);
+        $this->assertEquals($expected, $actual);
+
+        $path = Shoop::this(__DIR__)->divide("/")
+            ->dropLast()->append(["readme.html"])->asString("/");
+        $expected = file_get_contents($path);
+
+        $path = Shoop::this(__DIR__)->divide("/")
+            ->dropLast()->append(["README.md"])->asString("/");
+        $markdown = file_get_contents($path);
+
+        $actual = $converter->convertToHtml($markdown);
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/short-doc-attributes.md
+++ b/tests/short-doc-attributes.md
@@ -1,0 +1,3 @@
+[.USWDS](United States Web Design System){data-inline-attribute="hello"}
+
+[External link check](https://8fold.pro)


### PR DESCRIPTION
This allows for both [in-content attributes](https://commonmark.thephpleague.com/extensions/attributes/) defined by content authors and also [manipulation in event listeners](https://commonmark.thephpleague.com/1.5/customization/event-dispatcher/#example).