### PR TITLE
Add methods to get and set the abbreviation and title

### DIFF
--- a/src/Abbreviation.php
+++ b/src/Abbreviation.php
@@ -16,6 +16,46 @@ class Abbreviation extends AbstractInline
         $this->title = $title;
     }
 
+    /**
+     * Get the abbreviation, e.g. "HTML".
+     *
+     * @return string
+     */
+    public function getAbbreviation(): string
+    {
+        return $this->abbr;
+    }
+
+    /**
+     * Set the abbreviation, e.g. "HTML".
+     *
+     * @param string $abbr
+     */
+    public function setAbbreviation(string $abbr): void
+    {
+        $this->abbr = $abbr;
+    }
+
+    /**
+     * Get the full form of the abbreviation, e.g "HyperText Markup Language".
+     *
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * Set the full form of the abbreviation, e.g "HyperText Markup Language".
+     *
+     * @param string $title
+     */
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
     public function isContainer(): bool
     {
         return true;


### PR DESCRIPTION
One feature that I needed that wasn't available is the ability to get and set the abbreviation and title after the ```Abbreviation``` nodes are constructed, e.g. to alter them in event listeners and so on. I'm not entirely sure if this is the right approach that I've chosen, so want to get your opinion @joshbruce. Rather than storing the abbreviation and title/description in ```Abbreviation::abbr``` and ```Abbreviation::title```, would it make more sense to extend [```AbstractStringContainer```](https://github.com/thephpleague/commonmark/blob/1.5/src/Inline/Element/AbstractStringContainer.php) and then we can set the 'title' as the ```title``` attribute with the functionality from my last pull request, and the abbreviation ('abbr') as the contents of ```AbstractStringContainer``` (which can be retrieved/set by ```getContent()``` and ```setContent()```. That way the private ```Abbreviation::abbr``` and ```Abbreviation::title``` are no longer needed and altering the element can be done in the same way as other core CommonMark inlines. I can make changes to the pull request if you like that direction.