### PR TITLE
Extend AbstractStringContainer for compatibility with ToC, etc.

### DIFF
--- a/src/Abbreviation.php
+++ b/src/Abbreviation.php
@@ -2,19 +2,11 @@
 
 namespace Eightfold\CommonMarkAbbreviations;
 
-use League\CommonMark\Inline\Element\AbstractInline;
+use League\CommonMark\Inline\Element\AbstractStringContainer;
 use League\CommonMark\HtmlElement;
 
-class Abbreviation extends AbstractInline
+class Abbreviation extends AbstractStringContainer
 {
-    private $abbr = "";
-    private $title = "";
-
-    public function __construct(string $abbr, string $title)
-    {
-        $this->abbr = $abbr;
-        $this->title = $title;
-    }
 
     public function isContainer(): bool
     {
@@ -25,8 +17,6 @@ class Abbreviation extends AbstractInline
     {
         $attributes = $this->getData('attributes', []);
 
-        $attributes['title'] = $this->title;
-
-        return new HtmlElement('abbr', $attributes, $this->abbr);
+        return new HtmlElement('abbr', $attributes, $this->content);
     }
 }

--- a/src/AbbreviationInlineParser.php
+++ b/src/AbbreviationInlineParser.php
@@ -36,7 +36,7 @@ class AbbreviationInlineParser implements InlineParserInterface
         $abbr = substr($abbr, 2);
         $abbr = substr($abbr, 0, -1);
         list($abbr, $title) = explode("](", $abbr, 2);
-        $elem = new Abbreviation($abbr, $title);
+        $elem = new Abbreviation($abbr, ['attributes' => ['title' => $title]]);
 
         $inlineContext->getContainer()->appendChild($elem);
 

--- a/tests/AbbreviationAbstractStringContainerTest.php
+++ b/tests/AbbreviationAbstractStringContainerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Eightfold\CommonMarkAbbreviations\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+use League\CommonMark\Environment;
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
+use League\CommonMark\Extension\TableOfContents\TableOfContentsExtension;
+
+use Eightfold\Shoop\Shoop;
+
+use Eightfold\CommonMarkAbbreviations\Abbreviation;
+use Eightfold\CommonMarkAbbreviations\AbbreviationExtension;
+
+/**
+ * Tests that CommonMark recognizes Abbreviation as AbstractStringContainer.
+ *
+ * The table of contents extension will automatically convert any instances of
+ * AbstractStringContainer to just their text contents, essentially stripping
+ * any markup from the headings themselves. This tests that the plain text (in
+ * this case the abbreviation) is output correctly.
+ */
+class AbbreviationAbstractStringContainerTest extends TestCase
+{
+    public function testParser()
+    {
+        $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new AbbreviationExtension());
+        $environment->addExtension(new ExternalLinkExtension());
+        $environment->addExtension(new HeadingPermalinkExtension());
+        $environment->addExtension(new TableOfContentsExtension());
+        $converter = new CommonMarkConverter([
+            "external_link" => ["open_in_new_window" => true]
+        ], $environment);
+
+        $path = Shoop::this(__DIR__)->append("/short-doc-abstract-string-container.md");
+        $markdown = \file_get_contents($path);
+        $expected = \file_get_contents("short-doc-abstract-string-container.html");
+        $actual = $converter->convertToHtml($markdown);
+        $this->assertEquals($expected, $actual);
+
+        $path = Shoop::this(__DIR__)->divide("/")
+            ->dropLast()->append(["readme.html"])->asString("/");
+        $expected = \file_get_contents($path);
+
+        $path = Shoop::this(__DIR__)->divide("/")
+            ->dropLast()->append(["README.md"])->asString("/");
+        $markdown = \file_get_contents($path);
+
+        $actual = $converter->convertToHtml($markdown);
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/short-doc-abstract-string-container.html
+++ b/tests/short-doc-abstract-string-container.html
@@ -1,0 +1,13 @@
+<ul class="table-of-contents">
+<li>
+<p><a href="#the-uswds">The USWDS</a></p>
+</li>
+<li>
+<p><a href="#another-heading">Another heading</a></p>
+</li>
+</ul>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+<h1><a id="user-content-the-uswds" href="#the-uswds" name="the-uswds" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>The <abbr title="United States Web Design System">USWDS</abbr></h1>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+<h1><a id="user-content-another-heading" href="#another-heading" name="another-heading" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Another heading</h1>
+<p><a rel="noopener noreferrer" target="_blank" href="https://8fold.pro">External link check</a></p>

--- a/tests/short-doc-abstract-string-container.md
+++ b/tests/short-doc-abstract-string-container.md
@@ -1,0 +1,9 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+# The [.USWDS](United States Web Design System)
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+# Another heading
+
+[External link check](https://8fold.pro)


### PR DESCRIPTION
thephpleague/commonmark@b6b080a974a5f654fd2664a8f74a6e0ca156d461 fixed unparsed inline Markdown ending up in the table of contents (yay!) but seems to have caused abbreviations to be totally stripped from the table of contents (less yay) due to said fix checking if any elements it finds are an ```AbstractStringContainer```, and since ```Abbreviation``` does not extend ```AbstractStringContainer```, the table of contents just chucks it out rather than outputting the plain text contents. This pull request fixes that problem by extending ```AbstractStringContainer``` so that CommonMark core (and potentially other extensions) see abbreviations as standard string containers with the expected methods for getting and setting content.